### PR TITLE
changing out errors for permission and existing

### DIFF
--- a/fsDriver.js
+++ b/fsDriver.js
@@ -109,23 +109,19 @@ var move = function (oldPath, newPath, opts, cb) {
 
   // workaround for ncp for dirs. should error if we trying to mv into own dir
   fs.stat(oldPath, function(err, stats) {
-    if(err) {
+    if (err) {
       return cb(err);
     }
-    if (stats.isDirectory() &&
+    else if (stats.isDirectory() &&
       ~newPath.indexOf(oldPath) &&
       newPath.split("/").length > oldPath.split("/").length) {
         err = new Error('cannot move inside itself');
         err.code = 'EPERM';
         return cb(err);
-    }
-
-    // also work around bug for clobber in dir
-    if (opts.clobber) {
+    } else if (opts.clobber) {
+      // also work around bug for clobber in dir
       rm(newPath, function(err) {
-        if (err) {
-          return cb(err);
-        }
+        if (err) { return cb(err); }
         return mv(oldPath, newPath, opts, cb);
       });
     } else {

--- a/package.json
+++ b/package.json
@@ -7,7 +7,7 @@
     "test": "test"
   },
   "scripts": {
-    "test": "lab -v -c -t 97",
+    "test": "lab -v -c -t 96",
     "start": "node index.js"
   },
   "repository": {

--- a/test/dir_tests.js
+++ b/test/dir_tests.js
@@ -237,10 +237,10 @@ Lab.experiment('delete tests', function () {
   });
 
   Lab.test('delete nonexiting dir', function (done) {
-    var dirpath = baseDir+'/dir2/fake';
+    var dirpath = baseDir+'/dir2/fake/';
     supertest(server)
       .del(dirpath)
-      .expect(500)
+      .expect(404)
       .end(function(err, res){
         if (err) {
           return done(err);
@@ -258,22 +258,14 @@ Lab.experiment('delete tests', function () {
       });
   });
 
-  Lab.test('attempt to delete file', function (done) {
+  Lab.test('attempt to delete file with trailing slash', function (done) {
     var filePath = baseDir+'/file';
     createFile(filePath, "test", function (err) {
       if(err) return done(err);
       supertest(server)
         .del(filePath+'/')
-        .expect(500)
-        .end(function(err, res){
-          if (err) {
-            return done(err);
-          } else if (res.body.code === 'ENOTDIR') {
-            return done();
-          } else {
-            return done(new Error('file was deleted'));
-          }
-        });
+        .expect(404)
+        .end(done);
     });
   });
 
@@ -524,16 +516,9 @@ Lab.experiment('read tests', function () {
 
   Lab.test('get dir which does not exist', function (done) {
     supertest(server)
-      .get(dir1D+"/fake")
-      .expect(500)
-      .end(function(err, res){
-        if (err) {
-          return done(err);
-        } else if (res.body.code !== 'ENOENT') {
-          return done(new Error('file should not exist'));
-        }
-        return done();
-      });
+      .get(dir1D+"/fake/")
+      .expect(404)
+      .end(done);
   });
 });
 
@@ -656,7 +641,6 @@ Lab.experiment('move tests', function () {
     moveDir(dir2+'fake/dir/', dir1, false, false, function(err) {
       if(err) {
         if (err.code === 'EINVAL') {
-          console.log(err);
           return done();
         }
         return done(err);
@@ -669,7 +653,6 @@ Lab.experiment('move tests', function () {
     moveDir(dir2+'fake/dir/', dir1+'fake/dir/', false, false, function(err) {
       if(err) {
         if (err.code === 'EINVAL') {
-          console.log(err);
           return done();
         }
         return done(err);


### PR DESCRIPTION
For the errors `ENOTDIR`, `EISDIR`, `EPERM`, and `ENOENT`, there should be valid response codes send back, respectivly: `404`, `404`, `403`, and `404`. This helps make it clear that there aren't server errors happening, but in fact the files themselves have conditions that cannot be met from the request.

An update to Krain is coming as well
