### PR TITLE
Add fs module override + base path

### DIFF
--- a/fileserver.js
+++ b/fileserver.js
@@ -3,17 +3,14 @@ var bodyParser = require('body-parser');
 var fileDriver = require('./fsDriver.js');
 var url = require('url');
 var mime = require('mime');
-var path = require('path');
-var mw = require('dat-middleware');
-var flow = require('middleware-flow');
 var morgan = require('morgan');
 var error = require('debug')('rest-fs:fileserver');
 
-var fileserver = function(app) {
+var fileserver = function(app, opts) {
   if (!app) {
     throw new Error('express app required');
   }
-
+  fileDriver = fileDriver(opts);
   app.set('etag', 'strong');
   app.use(require('express-domain-middleware'));
   app.use(bodyParser.json());

--- a/index.js
+++ b/index.js
@@ -2,6 +2,6 @@ var express = require('express');
 var app = express();
 var fileserver = require('./fileserver.js');
 
-fileserver(app);
+fileserver(app, {fs: require('fs'), basePath: ''});
 
 app.listen(3000);


### PR DESCRIPTION
Goal was to allow use of any fs interface e.g. [s3fs](https://www.npmjs.com/package/s3fs), [ftpfs](https://github.com/maxogden/ftpfs), possibly [browserify-fs](https://github.com/mafintosh/browserify-fs) etc..

This brings down to removing dependencies mv, rimraf, findit and using provided/native fs only 
Adds ability to set basePath
TODO:
- [ ] probably breaks recursive listAll
- [ ] mkdir -p
- [ ] rm dir with objects in it
- [ ] make basePath invisible to rest api

posting a WIP pull request to get some feedback/ideas